### PR TITLE
Disabled alphanumeric validation for phone numbers

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -69,11 +69,16 @@ Client.prototype.sendSMS = function(from, to, message, whendelivered, callback) 
   if (!from) throw new Error('The param \'from\' was not supplied.');
   if (!to) throw new Error('The param \'to\' was not supplied.');
   if (!message) throw new Error('The param \'message\' was not supplied.');
-  if (from.length > 11) throw new Error('\'from\' can\'t be longer than 11 '+
-                                        'charcters.');
-  if (!from.match(/^[a-zA-Z0-9]+$/)) throw new Error('\'from\' can only '+
-                                                     'contain a-z, A-Z and '+
-                                                     '0-9');
+  
+  // If "from" is not a phonenumber, do alphanumeric validation
+  if (!from.match(/(^\+[0-9]+$)|(^[0-9]+$)/)) {
+    if (from.length > 11) throw new Error('\'from\' can\'t be longer than 11 '+
+                                          'charcters.');
+    if (!from.match(/^[a-zA-Z0-9]+$/)) throw new Error('\'from\' can only '+
+                                                       'contain a-z, A-Z and '+
+                                                       '0-9');
+  }
+  
   if (to.split(',').length > 200) throw new Error('\'to\' can\'t contain more '+
                                                   'than 200 numbers');
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -70,8 +70,9 @@ Client.prototype.sendSMS = function(from, to, message, whendelivered, callback) 
   if (!to) throw new Error('The param \'to\' was not supplied.');
   if (!message) throw new Error('The param \'message\' was not supplied.');
   
-  // If "from" is not a phonenumber, do alphanumeric validation
-  if (!from.match(/(^\+[0-9]+$)|(^[0-9]+$)/)) {
+  var alphanumeric = !from.match(/^\+?[0-9]+$/);
+
+  if (alphanumeric) {
     if (from.length > 11) throw new Error('\'from\' can\'t be longer than 11 '+
                                           'charcters.');
     if (!from.match(/^[a-zA-Z0-9]+$/)) throw new Error('\'from\' can only '+


### PR DESCRIPTION
46Elks API accepts allocated and unclocked numbers to be longer than 11 chars and with character "+". Only alphanumeric "from" -field should be validated.
